### PR TITLE
fix: trying to get headers after page is closed

### DIFF
--- a/packages/playwright-msw/src/server.ts
+++ b/packages/playwright-msw/src/server.ts
@@ -59,9 +59,9 @@ export const createServer = async (
 ): Promise<MockServiceWorker> => {
   let cachedHandlers: RequestHandler[] = originalHandlers;
 
-  await page.route("**/*", (route) => {
+  await page.route("**/*", async (route) => {
     try {
-      void handleRoute(route, cachedHandlers);
+      await handleRoute(route, cachedHandlers);
     } catch (error: unknown) {
       void route.fulfill({
         status: 502,


### PR DESCRIPTION
This change helps to fix https://github.com/valendres/playwright-msw/issues/26 in my case. But I don't really know why it fixes it so feel free to close this PR if it actually doesn't fix anything.