### PR TITLE
fix(api): `createWorker` is not exported

### DIFF
--- a/packages/playwright-msw/src/index.ts
+++ b/packages/playwright-msw/src/index.ts
@@ -1,2 +1,2 @@
-export * from './fixture';
-export { MockServiceWorker } from './worker';
+export { createWorkerFixture } from './fixture';
+export { MockServiceWorker, createWorker } from './worker';


### PR DESCRIPTION
First of, thank you for this package! When integrating MSW with Playwright in the past, I thought about using MSW handlers with Playwright routes as well. In the end, I decided to use [@mswjs/http-middleware](https://github.com/mswjs/http-middleware) and spawn an Express server for each Playwright worker, which was quicker and much easier but also haves it's own drawbacks. Mainly, the fact that each MSW server had it's own port when run in parallel, which had to be patched into the Web bundle on the fly while serving a request. This package makes the integration much easier.

Anyway, I noticed that the documentation describes `createWorker` as an available function but it isn't actually exported together with `createWorkerFixture`.

This PR updates the main package entrypoint to export `createWorker` as well.