### PR TITLE
feat: add support for mocking cross-origin requests

### DIFF
--- a/packages/example/src/components/search.tsx
+++ b/packages/example/src/components/search.tsx
@@ -75,6 +75,9 @@ export const Search: FC = () => {
       >
         <option value="/api/search">/api/search</option>
         <option value="/api/search/">/api/search/</option>
+        <option value="http://localhost:8080/api/search">
+          http://localhost:8080/api/search
+        </option>
       </select>
       <h1>Search engine</h1>
       <form onSubmit={handleFormChange}>

--- a/packages/example/tests/playwright/models/search-engine.ts
+++ b/packages/example/tests/playwright/models/search-engine.ts
@@ -33,7 +33,12 @@ export class SearchEngine {
     await expect(this.page.getByText(expectedSearchResult)).toBeVisible();
   }
 
-  async useEndpoint(endpoint: '/api/search' | '/api/search/') {
+  async useEndpoint(
+    endpoint:
+      | '/api/search'
+      | '/api/search/'
+      | 'http://localhost:8080/api/search'
+  ) {
     await this.page.getByTestId('endpoint').selectOption(endpoint);
   }
 }

--- a/packages/example/tests/playwright/specs/cross-origin.spec.ts
+++ b/packages/example/tests/playwright/specs/cross-origin.spec.ts
@@ -1,0 +1,65 @@
+import { SearchEngine } from '../models/search-engine';
+import { test } from '../test';
+import { rest } from 'msw';
+
+test.describe.parallel('cross-origin mocking', () => {
+  test('should allow request to be intercepted from a different backend server with a wildcard origin', async ({
+    page,
+    worker,
+  }) => {
+    await worker.resetHandlers(
+      rest.get('*/api/search', (_, response, context) =>
+        response(
+          context.status(200),
+          context.json([
+            {
+              title: 'Wildcard cross-domain result',
+              href: 'https://fake.domain.com/',
+              category: 'books',
+            },
+          ])
+        )
+      )
+    );
+
+    await page.goto('/search');
+    const searchEngine = new SearchEngine(page);
+    await searchEngine.useEndpoint('http://localhost:8080/api/search');
+    await searchEngine.setQuery('game');
+    await searchEngine.submit();
+    await searchEngine.assertSearchResultCount(1);
+    await searchEngine.assertSearchResultVisible(
+      'Wildcard cross-domain result'
+    );
+  });
+
+  test('should allow request to be intercepted from a different backend server with an explicit origin', async ({
+    page,
+    worker,
+  }) => {
+    await worker.resetHandlers(
+      rest.get('http://localhost:8080/api/search', (_, response, context) =>
+        response(
+          context.status(200),
+          context.json([
+            {
+              title: 'Explicit cross-domain result',
+              href: 'https://fake.domain.com/',
+              category: 'books',
+            },
+          ])
+        )
+      )
+    );
+
+    await page.goto('/search');
+    const searchEngine = new SearchEngine(page);
+    await searchEngine.useEndpoint('http://localhost:8080/api/search');
+    await searchEngine.setQuery('game');
+    await searchEngine.submit();
+    await searchEngine.assertSearchResultCount(1);
+    await searchEngine.assertSearchResultVisible(
+      'Explicit cross-domain result'
+    );
+  });
+});

--- a/packages/playwright-msw/src/utils.test.ts
+++ b/packages/playwright-msw/src/utils.test.ts
@@ -81,8 +81,8 @@ describe('utils', () => {
   });
 
   describe('convertMswPathToPlaywrightUrl', () => {
-    it.each<{ path: string; url: string; expected: boolean }>`
-      path                                                      | url                                                      | expected
+    it.each<{ mswPath: string; playwrightUrl: string; expected: boolean }>`
+      mswPath                                                   | playwrightUrl                                            | expected
       ${'/graphql'}                                             | ${'/graphql'}                                            | ${true}
       ${'/graphql'}                                             | ${'/graphql?query=GetSettings'}                          | ${true}
       ${'/user/:id'}                                            | ${'/user/1'}                                             | ${true}
@@ -124,9 +124,15 @@ describe('utils', () => {
       ${'https://www.google.com.au/:potato/:eggplant/?foo=bar'} | ${'https://www.google.com.au/search/something/'}         | ${true}
       ${'https://www.google.com.au/search'}                     | ${'https://different.domain/search'}                     | ${false}
       ${'http://www.google.com.au/:something/'}                 | ${'http://www.google.com.au/search/?q=potato'}           | ${true}
-    `('$expected: "$path" should match "$url"', ({ path, url, expected }) => {
-      const regex = convertMswPathToPlaywrightUrl(path);
-      expect(regex.test(url)).toBe(expected);
-    });
+      ${'*/api/users'}                                          | ${'http://localhost:8080/api/users'}                     | ${true}
+      ${'http://localhost:8080/api/users'}                      | ${'http://localhost:8080/api/users'}                     | ${true}
+      ${'http://localhost:8081/api/users'}                      | ${'http://localhost:8080/api/users'}                     | ${false}
+    `(
+      '$expected: "$mswPath" should match "$playwrightUrl"',
+      ({ mswPath, playwrightUrl, expected }) => {
+        const regex = convertMswPathToPlaywrightUrl(mswPath);
+        expect(regex.test(playwrightUrl)).toBe(expected);
+      }
+    );
   });
 });

--- a/packages/playwright-msw/src/utils.ts
+++ b/packages/playwright-msw/src/utils.ts
@@ -43,19 +43,19 @@ export const convertMswPathToPlaywrightUrl = (path: Path): RegExp => {
     return path;
   }
 
-  const originRegex = /(\w+:\/\/[^/]+)/u;
+  // Deconstruct path
+  const { origin, pathname } =
+    path.match(
+      /^(?<origin>\*|\w+:\/\/[^/]+)?(?<pathname>[^?]+)(?<search>\?.*)?/
+    )?.groups ?? {};
+
+  // Rebuild it as a RegExp
   return new RegExp(
     [
-      // Anchor to start of string
       '^',
-      // Add optional origin if path is a relative url
-      originRegex.test(path) ? '' : `${originRegex.source}?`,
-      // Mutate provided path
-      path
-        // Strip query parameters
-        .replace(/\?.*$/, '')
-        // Replace route parameters (`:whatever`) with multi-char wildcard
-        .replace(/:[^/]+(\/|\?)?/g, '[^/]+$1'),
+      origin === '*' ? '.*' : origin ?? '(\\w+://[^/]+)?',
+      // Replace route parameters (`:whatever`) with multi-char wildcard
+      pathname.replace(/:[^/]+/g, '[^/]+'),
       // Add optional trailing slash
       '\\/?',
       // Add optional query parameters


### PR DESCRIPTION
This PR addresses https://github.com/valendres/playwright-msw/issues/42 by adding support for mocking API calls from a different origin, either using an explicit origin(e.g. `http://localhost:8080/api/search`), or a wildcard origin (e.g. `*/api/search`). 