### PR TITLE
test: add test for passthrough / bypass of initial page load requests

### DIFF
--- a/packages/example/tests/playwright/specs/cross-origin.spec.ts
+++ b/packages/example/tests/playwright/specs/cross-origin.spec.ts
@@ -1,5 +1,5 @@
 import { SearchEngine } from '../models/search-engine';
-import { test } from '../test';
+import { test, expect } from '../test';
 import { rest } from 'msw';
 
 test.describe.parallel('cross-origin mocking', () => {
@@ -61,5 +61,30 @@ test.describe.parallel('cross-origin mocking', () => {
     await searchEngine.assertSearchResultVisible(
       'Explicit cross-domain result'
     );
+  });
+
+  test('should bypass initial page load requests (i.e. static assets)', async ({
+    page,
+    worker,
+  }) => {
+    await worker.resetHandlers(
+      rest.get('*/search', (_, response, context) =>
+        response(
+          context.status(200),
+          context.json([
+            {
+              title: 'Explicit cross-domain result',
+              href: 'https://fake.domain.com/',
+              category: 'books',
+            },
+          ])
+        )
+      )
+    );
+
+    await page.goto('/search');
+    await expect(
+      page.getByRole('heading', { name: 'Search engine' })
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
Added a (currently failing) test.

In `mockServiceWorker.js LS:220` `v(0.47.4)` they use this:

```ts
  // Bypass initial page load requests (i.e. static assets).
  // The absence of the immediate/parent client in the map of the active clients
  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
  // and is not ready to handle requests.
  if (!activeClientIds.has(client.id)) {
    return passthrough();
  }
  ```
  
  to handle passthroughs.
  
  Best guess is, that something like this needs to happen in the `handler.ts` or `router.ts` of this project.
  