### PR TITLE
test: add test case to ensure it works with msw graphql link

### DIFF
--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -8,10 +8,11 @@ import { UsersList } from './components/users-list';
 import { SettingsForm } from './components/settings-form';
 import { Documents } from './components/documents';
 import { Search } from './components/search';
+import { ENDPOINT1 } from './mocks/handlers/settings';
 
 const queryClient = new QueryClient();
 const apolloClient = new ApolloClient({
-  uri: '/graphql',
+  uri: ENDPOINT1,
   cache: new InMemoryCache(),
 });
 

--- a/packages/example/src/mocks/handlers/settings.ts
+++ b/packages/example/src/mocks/handlers/settings.ts
@@ -6,13 +6,18 @@ import {
   SettingsQueryData,
 } from '../../types/settings';
 
+export const ENDPOINT1 = 'https://first.endpoint/graphql';
+export const ENDPOINT2 = 'https://second.endpoint/graphql';
+export const graphql1 = graphql.link(ENDPOINT1);
+export const graphql2 = graphql.link(ENDPOINT2);
+
 const DEFAULT_SETTINGS: Settings = {
   enableNotifications: true,
   profileVisibility: 'private',
 };
 
 export default [
-  graphql.query<SettingsQueryData>('GetSettings', (_, response, context) =>
+  graphql1.query<SettingsQueryData>('GetSettings', (_, response, context) =>
     response(
       context.status(200),
       context.data({
@@ -20,7 +25,7 @@ export default [
       })
     )
   ),
-  graphql.mutation<SettingsMutationData, SettingsMutationVariables>(
+  graphql1.mutation<SettingsMutationData, SettingsMutationVariables>(
     'MutateSettings',
     (request, response, context) =>
       response(
@@ -30,4 +35,12 @@ export default [
         })
       )
   ),
+  graphql2.query<SettingsQueryData>('GetSettings', (_, response, context) => {
+    return response(
+      context.status(200),
+      context.data({
+        settings: { enableNotifications: false, profileVisibility: 'public' },
+      })
+    );
+  }),
 ];

--- a/packages/example/tests/playwright/models/settings-form.ts
+++ b/packages/example/tests/playwright/models/settings-form.ts
@@ -18,6 +18,10 @@ export class SettingsForm {
     await this.page.getByRole('button', { name: 'Update' }).click();
   }
 
+  async setUseEndpoint2(checked: boolean) {
+    await this.page.getByLabel('Use Endpoint 2').setChecked(checked);
+  }
+
   async setNotificationsEnabled(enabled: boolean) {
     await this.page.getByLabel('Notifications').setChecked(enabled);
   }

--- a/packages/example/tests/playwright/specs/graphql.spec.ts
+++ b/packages/example/tests/playwright/specs/graphql.spec.ts
@@ -55,4 +55,19 @@ test.describe.parallel('GraphQL example: user settings', () => {
     await settingsForm.submit();
     await settingsForm.assertError(SettingsForm.Error.MutationFailed);
   });
+
+  test('should render different data based on endpoint switching', async ({
+    page,
+  }) => {
+    await page.goto('/settings');
+
+    const settingsForm = new SettingsForm(page);
+    await settingsForm.setUseEndpoint2(true);
+    await settingsForm.assertNotificationsEnabled(false);
+    await settingsForm.assertProfileVisibility('public');
+
+    await settingsForm.setUseEndpoint2(false);
+    await settingsForm.assertNotificationsEnabled(true);
+    await settingsForm.assertProfileVisibility('private');
+  });
 });


### PR DESCRIPTION
Hi, regarding [issue#63](https://github.com/valendres/playwright-msw/issues/63)
 I would like to propose an update to the library to support multiple endpoints for GraphQL use cases.

After testing the official msw feature [graphql.link](https://mswjs.io/docs/api/graphql/link), I discovered that this library can already work with this API. As a result, I have added an integration test and made minor UI adjustments to the example settings-form page to provide an example and testing for this use case.

Please let me know that if there anything need to be added or modified.