### PR TITLE
Fix typo in README

### DIFF
--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -2,7 +2,7 @@
 
 A [React](https://reactjs.org/) SPA that utilises [MSW](https://mswjs.io/) to improve development experience. Additionally, it also has a number of [Playwright](https://playwright.dev/) tests to make sure that `playwright-msw`'s integration of the two libraries works as expected.
 
-The SPA contains two different different mechanisms for communicating with a server:
+The SPA contains two different mechanisms for communicating with a server:
 
 1. [REST](https://restfulapi.net/) via [ReactQuery](https://tanstack.com/query)
 2. [GraphQL](https://graphql.org/) via [Apollo](https://www.apollographql.com/docs/react/)


### PR DESCRIPTION
## Fix Typo in README

Hello,

This pull request addresses a small typo found in the README file. In the section describing the SPA's server communication mechanisms, the word "different" was accidentally repeated. This PR corrects this to improve the readability and professionalism of the documentation.

### Changes Made
- Updated the `README.md` file to fix the typo in the server communication mechanisms section.

This change is a small but important step towards maintaining the quality of the documentation. I believe this update will make the README clearer to new users and contributors.

Thank you for considering this pull request. I look forward to any feedback.

Best regards,
Bonhaeng Lee