### PR TITLE
fix: clone response before mutating it as of ISSUE-103

### DIFF
--- a/packages/playwright-msw/src/handler.ts
+++ b/packages/playwright-msw/src/handler.ts
@@ -36,11 +36,8 @@ export const handleRoute = async (route: Route, handlers: RequestHandler[]) => {
            */
           baseUrl: url.origin,
         },
-        onMockedResponse: async ({
-          status,
-          headers: rawHeaders,
-          body: rawBody,
-        }) => {
+        onMockedResponse: async (response) => {
+          const { status, headers: rawHeaders, body: rawBody } = response.clone();
           const contentType = rawHeaders.get('content-type') ?? undefined;
           const headers = objectifyHeaders(rawHeaders);
           const body = await readableStreamToBuffer(contentType, rawBody);


### PR DESCRIPTION
As mentioned in [ISSUE-103](https://github.com/valendres/playwright-msw/issues/103).

> an error is happening when same API endpoint is triggered multiple times during test execution. Seems like error comes from [onMockedResponse](https://github.com/valendres/playwright-msw/blob/main/packages/playwright-msw/src/handler.ts#L39) method, comparing it with [same method from msw](https://github.com/mswjs/msw/blob/main/src/browser/setupWorker/start/createRequestListener.ts#L57C1-L57C13) we can see that response is cloned before usage. When I've added response.clone() problem is gone.