### PR TITLE
Handle multiple `Set-Cookie` headers

### DIFF
--- a/packages/playwright-msw/package.json
+++ b/packages/playwright-msw/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@mswjs/cookies": "^1.1.0",
+    "set-cookie-parser": "^2.7.1",
     "strict-event-emitter": "^0.5.1"
   },
   "devDependencies": {
@@ -46,6 +47,7 @@
     "@types/jest": "^29.5.10",
     "@types/node": "^20.10.3",
     "@types/rimraf": "4.0.5",
+    "@types/set-cookie-parser": "^2",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "msw": "2.0.10",

--- a/packages/playwright-msw/src/router.test.ts
+++ b/packages/playwright-msw/src/router.test.ts
@@ -84,6 +84,7 @@ describe('router', () => {
 
         expect(handleRoute).toHaveBeenCalledTimes(1);
         expect(handleRoute).toHaveBeenCalledWith(
+          page,
           expect.objectContaining({}),
           // Should be all of the initial handlers since we haven't added any non-user handlers
           requestHandlers.slice().reverse(),
@@ -102,10 +103,11 @@ describe('router', () => {
 
         const executeRoute = getRouteHandlerForPath(userPath, page);
         executeRoute(mockRoute(), mockRequest());
-        expect(handleRoute).toHaveBeenCalledWith(expect.objectContaining({}), [
-          initialUserHandler,
-          subsequentUserHandler,
-        ]);
+        expect(handleRoute).toHaveBeenCalledWith(
+          page,
+          expect.objectContaining({}),
+          [initialUserHandler, subsequentUserHandler],
+        );
       });
 
       test('should include all of the corresponding subsequently added handlers (without having provided initial handlers) when calling handleRoute', async () => {
@@ -120,10 +122,11 @@ describe('router', () => {
 
         const executeRoute = getRouteHandlerForPath(userPath, page);
         executeRoute(mockRoute(), mockRequest());
-        expect(handleRoute).toHaveBeenCalledWith(expect.objectContaining({}), [
-          subsequentUserHandler1,
-          subsequentUserHandler2,
-        ]);
+        expect(handleRoute).toHaveBeenCalledWith(
+          page,
+          expect.objectContaining({}),
+          [subsequentUserHandler1, subsequentUserHandler2],
+        );
       });
 
       test('should not include handlers from other routes when calling handleRoute', async () => {
@@ -148,6 +151,7 @@ describe('router', () => {
 
         expect(handleRoute).toHaveBeenCalledTimes(1);
         expect(handleRoute).toHaveBeenCalledWith(
+          page,
           expect.objectContaining({}),
           // Note the omission of friend handlers
           userHandlers.slice().reverse(),
@@ -175,6 +179,7 @@ describe('router', () => {
 
         expect(handleRoute).toHaveBeenCalledTimes(1);
         expect(handleRoute).toHaveBeenCalledWith(
+          page,
           expect.objectContaining({}),
           // Note the omission of subsequently added handlers
           [initialUserHandler2, initialUserHandler1],

--- a/packages/playwright-msw/src/router.ts
+++ b/packages/playwright-msw/src/router.ts
@@ -144,7 +144,7 @@ export class Router {
         return route.continue();
       }
       const requestHandlers = this.getRouteData(path)?.requestHandlers ?? [];
-      return handleRoute(route, requestHandlers);
+      return handleRoute(this.page, route, requestHandlers);
     };
     await this.page.route(convertMswPathToPlaywrightUrl(path), routeHandler);
     return routeHandler;

--- a/packages/playwright-msw/src/utils.ts
+++ b/packages/playwright-msw/src/utils.ts
@@ -1,4 +1,5 @@
 import { Path, RequestHandler } from 'msw';
+import setCookie from 'set-cookie-parser';
 import { Config } from './config';
 
 export type SerializedPathType = 'regexp' | 'string';
@@ -86,6 +87,26 @@ export const convertMswPathToPlaywrightUrl = (path: Path): RegExp => {
       '$',
     ].join(''),
   );
+};
+
+export const parseSetCookieHeaders = (headers: Headers) => {
+  return setCookie
+    .parse(headers.getSetCookie())
+    .map(({ expires, sameSite, ...cookie }) => {
+      let formattedExpires: number | undefined = undefined;
+      let validatedSameSite: 'Strict' | 'Lax' | 'None' | undefined = undefined;
+      if (expires) {
+        formattedExpires = expires.getTime() / 1000;
+      }
+      if (sameSite === 'Strict' || sameSite === 'Lax' || sameSite === 'None') {
+        validatedSameSite = sameSite;
+      }
+      return {
+        expires: formattedExpires,
+        sameSite: validatedSameSite,
+        ...cookie,
+      };
+    });
 };
 
 export function objectifyHeaders(headers: Headers): Record<string, string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,6 +3067,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/set-cookie-parser@npm:^2":
+  version: 2.4.10
+  resolution: "@types/set-cookie-parser@npm:2.4.10"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 105cc90c7d7deeb344858f720b58bd137356586545ac00d1a448e050bfcc0f385553ff26bc9c674bd8c2e953a458149eadb1945ee3d1eee81e6c0656236ebc0a
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -8648,10 +8657,12 @@ __metadata:
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.10.3"
     "@types/rimraf": "npm:4.0.5"
+    "@types/set-cookie-parser": "npm:^2"
     babel-jest: "npm:^29.7.0"
     jest: "npm:^29.7.0"
     msw: "npm:2.0.10"
     rimraf: "npm:5.0.5"
+    set-cookie-parser: "npm:^2.7.1"
     strict-event-emitter: "npm:^0.5.1"
     typescript: "npm:5.3.2"
   peerDependencies:
@@ -9407,6 +9418,13 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "set-cookie-parser@npm:2.7.1"
+  checksum: c92b1130032693342bca13ea1b1bc93967ab37deec4387fcd8c2a843c0ef2fd9a9f3df25aea5bb3976cd05a91c2cf4632dd6164d6e1814208fb7d7e14edd42b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

`msw` allows [setting cookies](https://mswjs.io/docs/recipes/cookies/#mock-response-cookies) in mock handlers by setting the `Set-Cookie` header. 

```typescript
http.post("/api/login", () => {
  return new HttpResponse(null, { 
    headers: {
      "Set-Cookie": "token=my-token"
    }
  })
})
```

As long as a single `Set-Cookie` header is set, `playwright-msw` handles it perfectly. However, `msw` also accepts a `Headers` object. The spec allows storing multiple entries of the same header stored as comma-separated strings. These multi-entries headers can be constructed using [`append`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/append). It's such a common use-case that the spec includes a [`getSetCookie`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie) utility function to retrieve the array of `Set-Cookie` headers.

```typescript
http.post('/api/login', () => {
  const headers = new Headers()
  headers.append("Set-Cookie", "accessToken=my-access-token")
  headers.append("Set-Cookie", "refreshToken=my-refresh-token")
  console.log(headers.get("Set-Cookie") // "accessToken=my-access-token, refreshToken=my-refresh-token"
  console.log(headers.getSetCookie()) // ["accessToken=my-access-token", "refreshToken=my-refresh-token"]
  return new HttpResponse(null, { headers })
})
```

And this is where the issue arises: Playwright's `route.fulfill` function expects a `Record<string, string>` for the headers, but it does not handle comma-separated values. The current implementation iterates over the header entries from the mocked response to create an object compliant with `route.fulfill`, as a consequence only the last entry of each header is accounted for. 

## Proposed solution

Playwright exposes the `BrowserContext.addCookies` function which could be used to set cookies instead of relying on `route.fulfill`. However the function does not handle cookie strings, but rather a parsed version. I implemented a `parseSetCookieHeades` function converting the mocked response headers into a `BrowserContext.addCookies` compliant object, and updated the `onMockedResponse` callback of `msw`'s `handleRequest` function to handle `Set-Cookie` headers separately from the other headers.