### PR TITLE
feat: add ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "scripts": {
-    "build": "yarn workspaces foreach run build",
+    "build": "yarn workspaces foreach --all run build",
     "deploy": "monodeploy --config-file  monodeploy.config.js",
     "format": "prettier --write .",
     "lint": "eslint \"**/{src,tests}/**/*\"",

--- a/packages/playwright-msw/package.json
+++ b/packages/playwright-msw/package.json
@@ -2,7 +2,12 @@
   "name": "playwright-msw",
   "version": "3.0.1",
   "description": "A Mock Service Worker API for Playwright.",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
+  "type": "module",
+  "exports": {
+    "require": "./lib/cjs/index.js",
+    "import": "./lib/esm/index.js"
+  },
   "files": [
     "lib"
   ],
@@ -21,7 +26,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project ./tsconfig.json && tsc --project ./tsconfig.esm.json",
     "clean": "rimraf lib",
     "prepack": "yarn clean && yarn build",
     "test": "jest",

--- a/packages/playwright-msw/src/fixture.ts
+++ b/packages/playwright-msw/src/fixture.ts
@@ -1,7 +1,7 @@
 import type { PlaywrightTestArgs, TestFixture } from '@playwright/test';
 import { RequestHandler } from 'msw';
-import { Config } from './config';
-import { createWorker, MockServiceWorker } from './worker';
+import { Config } from './config.js';
+import { createWorker, MockServiceWorker } from './worker.js';
 
 export const createWorkerFixture = (
   handlers: RequestHandler[] = [],

--- a/packages/playwright-msw/src/handler.ts
+++ b/packages/playwright-msw/src/handler.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import type { RequestHandler, LifeCycleEventsMap } from 'msw';
 import { handleRequest } from 'msw';
 import { Emitter } from 'strict-event-emitter';
-import { objectifyHeaders, readableStreamToBuffer } from './utils';
+import { objectifyHeaders, readableStreamToBuffer } from './utils.js';
 
 const emitter = new Emitter<LifeCycleEventsMap>();
 

--- a/packages/playwright-msw/src/index.ts
+++ b/packages/playwright-msw/src/index.ts
@@ -1,3 +1,3 @@
-export { Config } from './config';
-export { createWorkerFixture } from './fixture';
-export { MockServiceWorker, createWorker } from './worker';
+export { Config } from './config.js';
+export { createWorkerFixture } from './fixture.js';
+export { MockServiceWorker, createWorker } from './worker.js';

--- a/packages/playwright-msw/src/router.ts
+++ b/packages/playwright-msw/src/router.ts
@@ -7,9 +7,9 @@ import {
   deserializePath,
   SerializedPath,
   convertMswPathToPlaywrightUrl,
-} from './utils';
-import { Config, DEFAULT_CONFIG } from './config';
-import { handleRoute } from './handler';
+} from './utils.js';
+import { Config, DEFAULT_CONFIG } from './config.js';
+import { handleRoute } from './handler.js';
 
 export type RouteUrl = string | RegExp;
 

--- a/packages/playwright-msw/src/utils.ts
+++ b/packages/playwright-msw/src/utils.ts
@@ -1,5 +1,5 @@
 import { Path, RequestHandler } from 'msw';
-import { Config } from './config';
+import { Config } from './config.js';
 
 export type SerializedPathType = 'regexp' | 'string';
 export type SerializedPath = `${SerializedPathType}:${string}`;

--- a/packages/playwright-msw/src/worker.ts
+++ b/packages/playwright-msw/src/worker.ts
@@ -1,8 +1,8 @@
 import type { Page } from '@playwright/test';
 import { store } from '@mswjs/cookies';
 import type { RequestHandler } from 'msw';
-import { Router } from './router';
-import { Config } from './config';
+import { Router } from './router.js';
+import { Config } from './config.js';
 
 export type MockServiceWorker = {
   /**

--- a/packages/playwright-msw/tsconfig.esm.json
+++ b/packages/playwright-msw/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./lib/esm"
+  }
+}

--- a/packages/playwright-msw/tsconfig.json
+++ b/packages/playwright-msw/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "outDir": "./lib",
+    "outDir": "./lib/cjs",
     "removeComments": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
This package no longer works with the latest msw releases (as of 2.8) due to ESM/CJS incompatibilities.

This PR adds a tsconfig.esm.json for transpiling into (and exporting) ESM syntax.
