### PR TITLE
chore: update github actions upload-artifact to v3

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2t64 libffi8 libx264-dev
       - name: Install dependencies
         run: yarn
       - name: Install Playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,16 +7,12 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libasound2t64 libffi8 libx264-dev
       - name: Install dependencies
         run: yarn
       - name: Install Playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn packages/example run test
       - name: Run the example-vue app's tests
         run: yarn packages/example-vue run test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn packages/example run test
       - name: Run the example-vue app's tests
         run: yarn packages/example-vue run test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Update GitHub Actions Upload-Artifact to v4 per [documentation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) recommendations